### PR TITLE
Изменения под версию >=8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ composer require krugozor/database
 
 ## What is `krugozor/database`?
 
-`krugozor/database` is a PHP 8.0 class library for simple, convenient, fast and secure work with the MySql database, using
+`krugozor/database` is a PHP >= 8.0 class library for simple, convenient, fast and secure work with the MySql database, using
 the PHP extension [mysqli](https://www.php.net/en/mysqli).
 
 

--- a/README_rus.md
+++ b/README_rus.md
@@ -8,7 +8,7 @@ composer require krugozor/database
 
 ## Что такое `krugozor/database`?
 
-`krugozor/database` — библиотека классов на PHP 8.0 для простой, удобной, быстрой и безопасной работы с базой данных MySql, использующая расширение PHP [mysqli](https://www.php.net/manual/ru/book.mysqli.php).
+`krugozor/database` — библиотека классов на PHP >= 8.0 для простой, удобной, быстрой и безопасной работы с базой данных MySql, использующая расширение PHP [mysqli](https://www.php.net/manual/ru/book.mysqli.php).
 
 
 ### Зачем нужен самописный класс для MySql, если в PHP есть абстракция PDO и расширение mysqli?

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,12 @@
     "prepare statement",
     "mysql class",
     "mysql database class",
-    "mysql database php class"
+    "mysql database php class",
+    "mysql db",
+    "mysql db class",
+    "php class mysql",
+    "php class mysql database",
+    "php class database"
   ],
   "require": {
     "php": ">=8.0",


### PR DESCRIPTION
В PHP 8.1.0 теперь по умолчанию установлено значение `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT`. Ранее оно было `MYSQLI_REPORT_OFF`. Следовательно, теперь вместо notice выбрасывается исключение `mysqli_sql_exception`. 

Библиотека перехватывает исключение `mysqli_sql_exception` в режиме `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT`, в остальных режимах информация об ошибках берётся. как и раньше, из объекта `mysqli`.

Оба случая библиотека корректно обработает и вернёт своё внутренне исключение `MySqlException`.
В случае режима `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT` исключение `mysqli_sql_exception` будет присутствовать в свойстве `previous` исключения `MySqlException`.